### PR TITLE
change project name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 cmake_minimum_required(VERSION 2.8.3)
-project(humanoid_17dof_description)
+project(freecad_to_gazebo)
 
 find_package(catkin REQUIRED COMPONENTS
   rospy


### PR DESCRIPTION
Compiling it I had this error: 

```log
CMake Error at /opt/ros/kinetic/share/catkin/cmake/catkin_package_xml.cmake:54 (message):
  catkin_package_xml() package name 'freecad_to_gazebo' in
  '/home/px/flexbe_ws/src/freecad_to_gazebo/package.xml' does not match
  current PROJECT_NAME 'humanoid_17dof_description'.  You must call project()
  with the same package name before.
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/catkin_python_setup.cmake:74 (catkin_package_xml)
  freecad_to_gazebo/CMakeLists.txt:8 (catkin_python_setup)
```
This PR correct this error

Signed-off-by: pxalcantara <pxalcantara@gmail.com>